### PR TITLE
Added "filterCategories" key for registerBroadcastReceiver

### DIFF
--- a/src/android/IntentShim.java
+++ b/src/android/IntentShim.java
@@ -204,6 +204,15 @@ public class IntentShim extends CordovaPlugin {
                 filter.addAction(filterActions.getString(i));
             }
 
+            //  Allow an array of filterCategories
+            JSONArray filterCategories = obj.has("filterCategories") ? obj.getJSONArray("filterCategories") : null;
+            if (filterCategories != null) {
+                for (int i = 0; i < filterCategories.length(); i++) {
+                    Log.d(LOG_TAG, "Registering broadcast receiver for category filter: " + filterCategories.getString(i));
+                    filter.addCategory(filterCategories.getString(i));
+                }
+            }
+            
             //  Add any specified Data Schemes
             //  https://github.com/darryncampbell/darryncampbell-cordova-plugin-intent/issues/24
             JSONArray filterDataSchemes = obj.has("filterDataSchemes") ? obj.getJSONArray("filterDataSchemes") : null;


### PR DESCRIPTION
Using different Android devices with built-in barcode scanners, we noticed that some (Datalogic) cannot send broadcast intents without setting a class.
In the original version of the plugin this means that the app cannot receive the intents using "registerBroadcastReceiver", because the class filter is missing.
Android docs say you shouldn't set a class when broadcasting, but when a hardware driver does (and cannot be prevented from doing so), we still should be able to receive the intent.
The addition in this patch is to read the key "filterCategories" and add the listed categories to the intent filter.
I hope the patch is clean enough to pull in, please contact me anytime if there are questions.