### PR TITLE
Fix NullPointerException caused by wrong authority for FileProvider

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -28,7 +28,7 @@
         <config-file target="AndroidManifest.xml" platform="android" parent="/manifest/application" mode="merge">
             <provider
                 android:name="android.support.v4.content.FileProvider"
-                android:authorities="${applicationId}.provider"
+                android:authorities="${applicationId}.fileprovider"
                 android:exported="false"
                 android:grantUriPermissions="true">
                 <meta-data


### PR DESCRIPTION
I got several crash reports in Google Play that had this cryptic stack trace:
```
java.lang.RuntimeException: 
  at android.app.ActivityThread.installProvider (ActivityThread.java:7110)
  at android.app.ActivityThread.installContentProviders (ActivityThread.java:6594)
  at android.app.ActivityThread.handleInstallProvider (ActivityThread.java:3559)
  at android.app.ActivityThread$H.handleMessage (ActivityThread.java:2141)
  at android.os.Handler.dispatchMessage (Handler.java:108)
  at android.os.Looper.loop (Looper.java:166)
  at android.app.ActivityThread.main (ActivityThread.java:7425)
  at java.lang.reflect.Method.invoke (Native Method)
  at com.android.internal.os.Zygote$MethodAndArgsCaller.run (Zygote.java:245)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:921)
Caused by: java.lang.NullPointerException: 
  at android.support.v4.content.FileProvider.parsePathStrategy (FileProvider.java:604)
  at android.support.v4.content.FileProvider.getPathStrategy (FileProvider.java:578)
  at android.support.v4.content.FileProvider.attachInfo (FileProvider.java:391)
  at android.app.ActivityThread.installProvider (ActivityThread.java:7107)
```

After some googling, I discovered that the authority for the FileProvider provider in AndroidManifest.xml should be `${applicationId}.fileprovider` instead of `${applicationId}.provider`, which is also what the official documentation specifies (https://developer.android.com/reference/android/support/v4/content/FileProvider).

Updating the app with this change seems to have silenced these crash reports. I'm not an expert in Android development, so I'd be glad if anyone could confirm that this change is correct.