### PR TITLE
added Intent.EXTRA_KEY_EVENT support

### DIFF
--- a/src/android/IntentShim.java
+++ b/src/android/IntentShim.java
@@ -553,6 +553,13 @@ public class IntentShim extends CordovaPlugin {
             } else if (key.equals(Intent.EXTRA_EMAIL)) {
                 // allows to add the email address of the receiver
                 i.putExtra(Intent.EXTRA_EMAIL, new String[] { valueStr });
+            } else if (key.equals(Intent.EXTRA_KEY_EVENT)) {
+                // allows to add a key event object
+                JSONObject keyEventJson = new JSONObject(valueStr);
+                int keyAction = keyEventJson.getInt("action");
+                int keyCode = keyEventJson.getInt("code");
+                KeyEvent keyEvent = new KeyEvent(keyAction, keyCode);
+                i.putExtra(Intent.EXTRA_KEY_EVENT, keyEvent);
             } else {
                 if (value instanceof Boolean) {
                     i.putExtra(key, Boolean.valueOf(valueStr));


### PR DESCRIPTION
Code example:
```
window.plugins.intentShim.sendBroadcast({
        "action": "android.intent.action.MEDIA_BUTTON",
        "extras": {
            "android.intent.extra.KEY_EVENT": JSON.stringify({
                "action": 0,
                "code": 85
            })
        }
    },
    function() {
        console.log('Sent Android broadcast intent');
    },
    function() {
        alert('Failed to send Android broadcast intent')
    }
);
```
With:
0: KeyEvent.ACTION_DOWN
85: KEYCODE_MEDIA_PLAY_PAUSE