### PR TITLE
Adding hook to add androidx support in gradle.properties

### DIFF
--- a/hooks/after_prepare.js
+++ b/hooks/after_prepare.js
@@ -1,0 +1,33 @@
+const fs = require("fs");
+
+function androidXUpgrade (ctx) {
+    if (!ctx.opts.platforms.includes('android'))
+        return;
+
+    const enableAndroidX = "android.useAndroidX=true";
+    const enableJetifier = "android.enableJetifier=true";
+    const gradlePropertiesPath = "./platforms/android/gradle.properties";
+
+    let gradleProperties = fs.readFileSync(gradlePropertiesPath, "utf8");
+
+    if (gradleProperties)
+    {
+        const isAndroidXEnabled = gradleProperties.includes(enableAndroidX);
+        const isJetifierEnabled = gradleProperties.includes(enableJetifier);
+
+        if (isAndroidXEnabled && isJetifierEnabled)
+            return;
+
+        if (isAndroidXEnabled === false)
+            gradleProperties += "\n" + enableAndroidX;
+
+        if (isJetifierEnabled === false)
+            gradleProperties += "\n" + enableJetifier;
+
+        fs.writeFileSync(gradlePropertiesPath, gradleProperties);
+    }
+}
+
+module.exports = function (ctx) {
+    androidXUpgrade(ctx);
+};

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,6 +4,8 @@
     <js-module name="IntentShim" src="www/IntentShim.js">
         <clobbers target="intentShim" />
     </js-module>
+    
+    <hook type="after_prepare" src="hooks/after_prepare.js" />
 	
 	<!-- android -->
     <platform name="android">


### PR DESCRIPTION
This hook will append the necessary values to the gradle.properties file after prepare.  These values are needed for androidx support.