### PR TITLE
Feature/androidx ionic

### DIFF
--- a/hooks/after_prepare.js
+++ b/hooks/after_prepare.js
@@ -1,0 +1,33 @@
+const fs = require("fs");
+
+function androidXUpgrade (ctx) {
+    if (!ctx.opts.platforms.includes('android'))
+        return;
+
+    const enableAndroidX = "android.useAndroidX=true";
+    const enableJetifier = "android.enableJetifier=true";
+    const gradlePropertiesPath = "./platforms/android/gradle.properties";
+
+    let gradleProperties = fs.readFileSync(gradlePropertiesPath, "utf8");
+
+    if (gradleProperties)
+    {
+        const isAndroidXEnabled = gradleProperties.includes(enableAndroidX);
+        const isJetifierEnabled = gradleProperties.includes(enableJetifier);
+
+        if (isAndroidXEnabled && isJetifierEnabled)
+            return;
+
+        if (isAndroidXEnabled === false)
+            gradleProperties += "\n" + enableAndroidX;
+
+        if (isJetifierEnabled === false)
+            gradleProperties += "\n" + enableJetifier;
+
+        fs.writeFileSync(gradlePropertiesPath, gradleProperties);
+    }
+}
+
+module.exports = function (ctx) {
+    androidXUpgrade(ctx);
+};

--- a/hooks/after_prepare.js
+++ b/hooks/after_prepare.js
@@ -1,4 +1,5 @@
 const fs = require("fs");
+const replace = require('replace-in-file');
 
 function androidXUpgrade (ctx) {
     if (!ctx.opts.platforms.includes('android'))
@@ -28,6 +29,18 @@ function androidXUpgrade (ctx) {
     }
 }
 
+function androidXReplace (ctx) {
+    if (!ctx.opts.platforms.includes('android'))
+        return;
+        
+    replace.sync({
+        files: 'platforms/android/**/*',
+        from: /android\.support\.annotation\.RequiresApi/g,
+        to: 'androidx.annotation.RequiresApi',
+    });
+}
+
 module.exports = function (ctx) {
     androidXUpgrade(ctx);
+    androidXReplace(ctx);
 };

--- a/plugin.xml
+++ b/plugin.xml
@@ -4,6 +4,8 @@
     <js-module name="IntentShim" src="www/IntentShim.js">
         <clobbers target="intentShim" />
     </js-module>
+    
+    <hook type="after_prepare" src="hooks/after_prepare.js" />
 	
 	<!-- android -->
     <platform name="android">


### PR DESCRIPTION
I added code to my last hook in https://github.com/darryncampbell/darryncampbell-cordova-plugin-intent/pull/85 to support Ionic v4, as their webview has an import to an old support library that breaks when androidx is enabled.  This may not be something you want to take responsibility for in your plugin, and may rather leave this for the consumers of your plugin to handle considering you're not specifically an Ionic plugin.  

I might suggest alternatively setting androidx support up as optional, and controlled by a variable at plugin install to allow for more users to be able to use it.  This may be a safer option until Cordova and Ionic are fully switched over to androidx.