### PR TITLE
Added the ability to add class instances to intents

### DIFF
--- a/src/android/IntentShim.java
+++ b/src/android/IntentShim.java
@@ -36,11 +36,14 @@ import org.json.JSONObject;
 
 import java.io.File;
 
+import java.io.Serializable;
 import java.lang.reflect.Array;
+import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import static android.os.Environment.getExternalStorageDirectory;
@@ -113,11 +116,12 @@ public class IntentShim extends CordovaPlugin {
             callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK));
             return true;
         }
-        else if (action.equals("registerBroadcastReceiver")) {
+        else if (action.equals("registerBroadcastReceiver"))
+        {
             Log.d(LOG_TAG, "Plugin no longer unregisters receivers on registerBroadcastReceiver invocation");
 
             //  No error callback
-            if(args.length() != 1) {
+            if (args.length() != 1) {
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                 return false;
             }
@@ -181,7 +185,7 @@ public class IntentShim extends CordovaPlugin {
         else if (action.equals("onIntent"))
         {
             //  Credit: https://github.com/napolitano/cordova-plugin-intent
-            if(args.length() != 1) {
+            if (args.length() != 1) {
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                 return false;
             }
@@ -200,7 +204,7 @@ public class IntentShim extends CordovaPlugin {
         }
         else if (action.equals("onActivityResult"))
         {
-            if(args.length() != 1) {
+            if (args.length() != 1) {
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                 return false;
             }
@@ -215,7 +219,7 @@ public class IntentShim extends CordovaPlugin {
         else if (action.equals("getIntent"))
         {
             //  Credit: https://github.com/napolitano/cordova-plugin-intent
-            if(args.length() != 0) {
+            if (args.length() != 0) {
                 callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
                 return false;
             }
@@ -238,10 +242,9 @@ public class IntentShim extends CordovaPlugin {
             //  Assuming this application was started with startActivityForResult, send the result back
             //  https://github.com/darryncampbell/darryncampbell-cordova-plugin-intent/issues/3
             Intent result = new Intent();
-            if (args.length() > 0)
-            {
+            if (args.length() > 0) {
                 JSONObject json = args.getJSONObject(0);
-                JSONObject extras = (json.has("extras"))?json.getJSONObject("extras"):null;
+                JSONObject extras = (json.has("extras")) ? json.getJSONObject("extras") : null;
 
                 // Populate the extras if any exist
                 if (extras != null) {
@@ -251,15 +254,14 @@ public class IntentShim extends CordovaPlugin {
                         Object extrasObj = extras.get(key);
                         if (extrasObj instanceof JSONObject) {
                             //  The extra is a bundle
-                            Bundle bundle = toBundle((JSONObject) extras.get(key));
-                            result.putExtra(key, bundle);
+                            result.putExtra(key, toBundle((JSONObject) extras.get(key)));
                         } else if (extrasObj instanceof Boolean) {
                             result.putExtra(key, extras.getBoolean(key));
-                        } else if(extrasObj instanceof Integer) {
+                        } else if (extrasObj instanceof Integer) {
                             result.putExtra(key, extras.getInt(key));
-                        } else if(extrasObj instanceof Long) {
+                        } else if (extrasObj instanceof Long) {
                             result.putExtra(key, extras.getLong(key));
-                        } else if(extrasObj instanceof Double) {
+                        } else if (extrasObj instanceof Double) {
                             result.putExtra(key, extras.getDouble(key));
                         } else if (extrasObj instanceof Float) {
                             result.putExtra(key, extras.getDouble(key));
@@ -297,7 +299,7 @@ public class IntentShim extends CordovaPlugin {
 
     private void unregisterAllBroadcastReceivers() {
         Log.d(LOG_TAG, "Unregistering all broadcast receivers, size was " + receiverCallbacks.size());
-        for (BroadcastReceiver broadcastReceiver: receiverCallbacks.keySet()) {
+        for (BroadcastReceiver broadcastReceiver: receiverCallbacks.keySet()){
             this.cordova.getActivity().unregisterReceiver(broadcastReceiver);
         }
         receiverCallbacks.clear();
@@ -341,8 +343,7 @@ public class IntentShim extends CordovaPlugin {
                 callbackContext.error("Storage directory is returning not mounted");
                 return null;
             }
-        }
-        catch(StringIndexOutOfBoundsException e)
+        } catch (StringIndexOutOfBoundsException e)
         {
             Log.e(LOG_TAG, "URL is not well formed");
             callbackContext.error("URL is not well formed");
@@ -411,14 +412,14 @@ public class IntentShim extends CordovaPlugin {
         return "Requires KK or higher";
     }
 
-    private void startActivity(Intent i, boolean bExpectResult,  int requestCode, CallbackContext callbackContext) {
+    private void startActivity(Intent i, boolean bExpectResult, int requestCode, CallbackContext callbackContext) {
 
         if (i.resolveActivityInfo(this.cordova.getActivity().getPackageManager(), 0) != null)
         {
             if (bExpectResult)
             {
                 cordova.setActivityResultCallback(this);
-               this.cordova.getActivity().startActivityForResult(i, requestCode);
+                this.cordova.getActivity().startActivityForResult(i, requestCode);
             }
             else
             {
@@ -445,7 +446,6 @@ public class IntentShim extends CordovaPlugin {
     private Intent populateIntent(JSONObject obj, CallbackContext callbackContext) throws JSONException
     {
         //  Credit: https://github.com/chrisekelley/cordova-webintent
-        //  Credit: https://github.com/chrisekelley/cordova-webintent
         String type = obj.has("type") ? obj.getString("type") : null;
         String packageAssociated = obj.has("package") ? obj.getString("package") : null;
 
@@ -467,8 +467,8 @@ public class IntentShim extends CordovaPlugin {
 
         JSONObject extras = obj.has("extras") ? obj.getJSONObject("extras") : null;
         Map<String, Object> extrasMap = new HashMap<String, Object>();
-        Bundle bundle = null;
-        String bundleKey = "";
+        JSONObject extrasObject = null;
+        String extrasKey = "";
         if (extras != null) {
             JSONArray extraNames = extras.names();
             for (int i = 0; i < extraNames.length(); i++) {
@@ -476,8 +476,8 @@ public class IntentShim extends CordovaPlugin {
                 Object extrasObj = extras.get(key);
                 if (extrasObj instanceof JSONObject) {
                     //  The extra is a bundle
-                    bundleKey = key;
-                    bundle = toBundle((JSONObject) extras.get(key));
+                    extrasKey = key;
+                    extrasObject = (JSONObject) extras.get(key);
                 } else {
                     extrasMap.put(key, extras.get(key));
                 }
@@ -512,7 +512,6 @@ public class IntentShim extends CordovaPlugin {
                 Log.w(LOG_TAG, "Component specified but missing corresponding package or class");
                 throw new JSONException("Component specified but missing corresponding package or class");
             }
-
             else
             {
                 ComponentName componentName = new ComponentName(componentPackage, componentClass);
@@ -533,8 +532,8 @@ public class IntentShim extends CordovaPlugin {
             }
         }
 
-        if (bundle != null)
-            i.putExtra(bundleKey, bundle);
+        if (extrasObject != null)
+            addSerializable(i, extrasKey, extrasObject);
 
         for (String key : extrasMap.keySet()) {
             Object value = extrasMap.get(key);
@@ -569,11 +568,11 @@ public class IntentShim extends CordovaPlugin {
             } else {
                 if (value instanceof Boolean) {
                     i.putExtra(key, Boolean.valueOf(valueStr));
-                } else if(value instanceof Integer) {
+                } else if (value instanceof Integer) {
                     i.putExtra(key, Integer.valueOf(valueStr));
-                } else if(value instanceof Long) {
+                } else if (value instanceof Long) {
                     i.putExtra(key, Long.valueOf(valueStr));
-                } else if(value instanceof Double) {
+                } else if (value instanceof Double) {
                     i.putExtra(key, Double.valueOf(valueStr));
                 } else {
                     i.putExtra(key, valueStr);
@@ -594,8 +593,7 @@ public class IntentShim extends CordovaPlugin {
     public void onNewIntent(Intent intent) {
         if (this.onNewIntentCallbackContext != null) {
             fireOnNewIntent(intent);
-        }
-        else {
+        } else {
             // save the intent for use when onIntent action is called in the execute method
             this.deferredIntent = intent;
         }
@@ -667,7 +665,7 @@ public class IntentShim extends CordovaPlugin {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             clipData = intent.getClipData();
-            if(clipData != null) {
+            if (clipData != null) {
                 int clipItemCount = clipData.getItemCount();
                 items = new JSONObject[clipItemCount];
 
@@ -704,7 +702,7 @@ public class IntentShim extends CordovaPlugin {
             intentJSON = new JSONObject();
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                if(items != null) {
+                if (items != null) {
                     intentJSON.put("clipItems", new JSONArray(items));
                 }
             }
@@ -755,15 +753,13 @@ public class IntentShim extends CordovaPlugin {
                 result.put(i, toJsonValue(Array.get(value, i)));
             }
             return result;
-        }
-        else if (value instanceof ArrayList<?>) {
+        }else if (value instanceof ArrayList<?>) {
             final ArrayList arrayList = (ArrayList<?>)value;
             final JSONArray result = new JSONArray();
             for (int i = 0; i < arrayList.size(); i++)
                 result.put(toJsonValue(arrayList.get(i)));
             return result;
-        }
-        else if (
+        } else if (
                 value instanceof String
                         || value instanceof Boolean
                         || value instanceof Integer
@@ -775,6 +771,56 @@ public class IntentShim extends CordovaPlugin {
         }
     }
 
+    private void addSerializable(Intent intent, String key, final JSONObject obj) {
+        if (obj.has("$class")) {
+            try {
+                JSONArray arguments = obj.has("arguments") ? obj.getJSONArray("arguments") : new JSONArray();
+
+                Class<?>[] argTypes = new Class[arguments.length()];
+                for (int i = 0; i < arguments.length(); i++) {
+                    argTypes[i] = getType(arguments.get(i));
+                }
+
+                Class<?> classForName = Class.forName(obj.getString("$class"));
+                Constructor<?> constructor = classForName.getConstructor(argTypes);
+
+                intent.putExtra(key, (Serializable) constructor.newInstance(jsonArrayToObjectArray(arguments)));
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        } else {
+            intent.putExtra(key, toBundle(obj));
+        }
+    }
+
+    private Object[] jsonArrayToObjectArray(JSONArray array) throws JSONException {
+        List<Object> list = new ArrayList<>();
+
+        for (int i = 0; i < array.length(); i++) {
+            list.add(array.get(i));
+        }
+
+        return list.toArray();
+    }
+
+    private Class<?> getType(Object obj) {
+        if (obj instanceof String) {
+            return String.class;
+        } else if (obj instanceof Boolean) {
+            return Boolean.class;
+        } else if (obj instanceof Float) {
+            return Float.class;
+        } else if (obj instanceof Integer) {
+            return Integer.class;
+        } else if (obj instanceof Long) {
+            return Long.class;
+        } else if (obj instanceof Double) {
+            return Double.class;
+        } else {
+            return null;
+        }
+    }
+
     private Bundle toBundle(final JSONObject obj) {
         Bundle returnBundle = new Bundle();
         if (obj == null) {
@@ -782,10 +828,9 @@ public class IntentShim extends CordovaPlugin {
         }
         try {
             Iterator<?> keys = obj.keys();
-            while(keys.hasNext())
-            {
+            while (keys.hasNext()) {
                 String key = (String)keys.next();
-                Object compare = obj.get(key);
+
                 if (obj.get(key) instanceof String)
                     returnBundle.putString(key, obj.getString(key));
                 else if (obj.get(key) instanceof Boolean)
@@ -831,7 +876,6 @@ public class IntentShim extends CordovaPlugin {
         catch (JSONException e) {
             e.printStackTrace();
         }
-
 
         return returnBundle;
     }


### PR DESCRIPTION
# Use case
We would like to call an intent of a third party app that requires that we provide a [`BigDecimal`](https://docs.oracle.com/javase/7/docs/api/java/math/BigDecimal.html) in the `Intent`. Since we are not able to transfer Java objects to JS (and back), we must have some solution in this library. The solution I came up with was to handle objects that contain the `$class` key in a special way, allowing the lib to create the object in Java with specific parameters.

# Example
```js
const amount = 2;

window.plugins.intentShim.startActivityForResult({
  action: '...',
  extras: {
    'bigDecimal': { $class: 'java.math.BigDecimal', arguments: [amount.toFixed(2)] },
  },
}, console.log, console.error);
```