### PR TITLE
Added packageExists

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,30 @@ Both `args` and `callback` arguments have to be provided. If you do not need the
         }
     );
 
+## intentShim.packageExists
+Returns a boolean indicating if a specific package is installed on the device.
+
+```js
+window.plugins.intentShim.packageExists(packageName, callback);
+```
+
+### Description
+
+The `intentShim.packageExists` function returns a boolean indicating if a specific [package](https://developer.android.com/studio/build/configure-app-module#set_the_application_id) is installed on the current device.
+
+### Example
+```js
+const packageName = 'com.android.contacts';
+
+window.plugins.intentShim.packageExists(packageName, (exists) => {
+    if (exists) {
+        console.log(`${packageName} exists!`);
+    } else {
+        console.log(`${packageName} does not exist...`);
+    }
+});
+```
+
 ## Predefined Constants
 
 The following constants are defined in the plugin for use in JavaScript

--- a/src/android/IntentShim.java
+++ b/src/android/IntentShim.java
@@ -291,6 +291,23 @@ public class IntentShim extends CordovaPlugin {
             return true;
 
         }
+        else if (action.equals("packageExists"))
+        {
+            try {
+                if (args.length() < 1) {
+                    callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.INVALID_ACTION));
+                    return false;
+                }
+
+                PackageManager packageManager = this.cordova.getActivity().getApplicationContext().getPackageManager();
+                packageManager.getPackageInfo(args.getString(0), 0);
+                callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, true));
+                return true;
+            } catch (PackageManager.NameNotFoundException e) {
+                callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, false));
+                return true;
+            }
+        }
 
         return true;
     }

--- a/www/IntentShim.js
+++ b/www/IntentShim.js
@@ -14,9 +14,9 @@ function IntentShim() {
 }
 
 IntentShim.prototype.ACTION_SEND = "android.intent.action.SEND";
-IntentShim.prototype.ACTION_VIEW= "android.intent.action.VIEW";
-IntentShim.prototype.ACTION_INSTALL_PACKAGE="android.intent.action.INSTALL_PACKAGE";
-IntentShim.prototype.ACTION_UNINSTALL_PACKAGE= "android.intent.action.UNINSTALL_PACKAGE";
+IntentShim.prototype.ACTION_VIEW = "android.intent.action.VIEW";
+IntentShim.prototype.ACTION_INSTALL_PACKAGE = "android.intent.action.INSTALL_PACKAGE";
+IntentShim.prototype.ACTION_UNINSTALL_PACKAGE = "android.intent.action.UNINSTALL_PACKAGE";
 IntentShim.prototype.EXTRA_TEXT = "android.intent.extra.TEXT";
 IntentShim.prototype.EXTRA_SUBJECT = "android.intent.extra.SUBJECT";
 IntentShim.prototype.EXTRA_STREAM = "android.intent.extra.STREAM";
@@ -29,59 +29,64 @@ IntentShim.prototype.ACTION_PICK = "android.intent.action.PICK";
 IntentShim.prototype.RESULT_CANCELED = 0; //  Activity.RESULT_CANCELED
 IntentShim.prototype.RESULT_OK = -1; //  Activity.RESULT_OK
 
-IntentShim.prototype.startActivity = function(params, successCallback, errorCallback) {
+IntentShim.prototype.startActivity = function (params, successCallback, errorCallback) {
     argscheck.checkArgs('off', 'IntentShim.startActivity', arguments);
     exec(successCallback, errorCallback, "IntentShim", "startActivity", [params]);
 };
 
-IntentShim.prototype.startActivityForResult = function(params, successCallback, errorCallback) {
+IntentShim.prototype.startActivityForResult = function (params, successCallback, errorCallback) {
     argscheck.checkArgs('off', 'IntentShim.startActivityForResult', arguments);
     exec(successCallback, errorCallback, "IntentShim", "startActivityForResult", [params]);
 };
 
-IntentShim.prototype.sendBroadcast = function(params, successCallback, errorCallback) {
+IntentShim.prototype.sendBroadcast = function (params, successCallback, errorCallback) {
     argscheck.checkArgs('off', 'IntentShim.sendBroadcast', arguments);
     exec(successCallback, errorCallback, "IntentShim", "sendBroadcast", [params]);
 };
 
-IntentShim.prototype.startService = function(params, successCallback, errorCallback) {
+IntentShim.prototype.startService = function (params, successCallback, errorCallback) {
     argscheck.checkArgs('off', 'IntentShim.startService', arguments);
     exec(successCallback, errorCallback, "IntentShim", "startService", [params]);
 };
 
-IntentShim.prototype.registerBroadcastReceiver = function(params, callback) {
+IntentShim.prototype.registerBroadcastReceiver = function (params, callback) {
     argscheck.checkArgs('of', 'IntentShim.registerBroadcastReceiver', arguments);
     exec(callback, null, "IntentShim", "registerBroadcastReceiver", [params]);
 };
 
-IntentShim.prototype.unregisterBroadcastReceiver = function() {
+IntentShim.prototype.unregisterBroadcastReceiver = function () {
     argscheck.checkArgs('', 'IntentShim.unregisterBroadcastReceiver', arguments);
     exec(null, null, "IntentShim", "unregisterBroadcastReceiver", []);
 };
 
-IntentShim.prototype.onIntent = function(callback) {
+IntentShim.prototype.onIntent = function (callback) {
     argscheck.checkArgs('f', 'IntentShim.onIntent', arguments);
     exec(callback, null, "IntentShim", "onIntent", [callback]);
 };
 
-IntentShim.prototype.onActivityResult = function(callback) {
+IntentShim.prototype.onActivityResult = function (callback) {
     argscheck.checkArgs('f', 'IntentShim.onActivityResult', arguments);
     exec(callback, null, "IntentShim", "onActivityResult", [callback]);
 };
 
-IntentShim.prototype.getIntent = function(successCallback, failureCallback) {
+IntentShim.prototype.getIntent = function (successCallback, failureCallback) {
     argscheck.checkArgs('ff', 'IntentShim.getIntent', arguments);
     exec(successCallback, failureCallback, "IntentShim", "getIntent", []);
 };
 
-IntentShim.prototype.sendResult = function(params, callback) {
+IntentShim.prototype.sendResult = function (params, callback) {
     argscheck.checkArgs('of', 'IntentShim.sendResult', arguments);
     exec(callback, null, "IntentShim", "sendResult", [params]);
 }
 
-IntentShim.prototype.realPathFromUri = function(params, successCallback, errorCallback) {
+IntentShim.prototype.realPathFromUri = function (params, successCallback, errorCallback) {
     argscheck.checkArgs('off', 'IntentShim.realPathFromUri', arguments);
     exec(successCallback, errorCallback, "IntentShim", "realPathFromUri", [params]);
+};
+
+IntentShim.prototype.packageExists = function (packageName, successCallback) {
+    argscheck.checkArgs('sf', 'IntentShim.packageExists', arguments);
+    exec(successCallback, null, "IntentShim", "packageExists", [packageName]);
 };
 
 window.intentShim = new IntentShim();


### PR DESCRIPTION
# Use case
We would like to know if we are able to start a specific intent before actually calling it. The solution I came up with was checking if the package that exposes the intent is available on the system.

# Example
```js
const packageName = 'com.android.contacts';

window.plugins.intentShim.packageExists(packageName, (exists) => {
    if (exists) {
        console.log(`${packageName} exists!`);
    } else {
        console.log(`${packageName} does not exist...`);
    }
});
```